### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/editorconfig-checker.yml
+++ b/.github/workflows/editorconfig-checker.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   editorconfig:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/josolanes/ContainrBot/security/code-scanning/1](https://github.com/josolanes/ContainrBot/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is restricted to only what this workflow needs.  
For this workflow, the best minimal fix is at the workflow root (applies to all jobs): `contents: read`. This preserves existing behavior (checkout needs repository read access) while removing unnecessary write privileges.

**File to change:** `.github/workflows/editorconfig-checker.yml`  
**Region:** after the `on:` trigger section and before `jobs:`.  
No imports, methods, or extra definitions are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
